### PR TITLE
Fix dead link

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -5,7 +5,7 @@ format: html
 ---
 
 ::: {.callout-warning}
-Work in progress. See the source [on GitHub](github.com/matt-dray/tatableble).
+Work in progress. See the source [on GitHub](https://github.com/matt-dray/tatableble).
 :::
 
 ```{r}


### PR DESCRIPTION
Original was linking to `https://matt-dray.github.io/tatableble/github.com/matt-dray/tatableble`